### PR TITLE
Fix `run!` for `AtomicJob`

### DIFF
--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -101,21 +101,15 @@ function run!(x::AtomicJob)
             ),
         )
         ref = try
-            _call(x.def)
+            result = _call(x.def)
+            x.status = SUCCEEDED
+            result
         catch e
             @error "could not spawn process `$(x.def)`! Come across `$e`!"
+            x.status = e isa InterruptException ? INTERRUPTED : FAILED
             e
         end
         x.stop_time = now()
-        if ref isa Exception  # Include all cases?
-            if ref isa InterruptException
-                x.status = INTERRUPTED
-            else
-                x.status = FAILED
-            end
-        else
-            x.status = SUCCEEDED
-        end
         row = filter(row -> row.id == x.id, JOB_REGISTRY)
         row.status = x.status
         row.stop_time = x.stop_time

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -102,14 +102,15 @@ function run!(x::AtomicJob)
         )
         ref = try
             result = _call(x.def)
+            x.stop_time = now()
             x.status = SUCCEEDED
             result
         catch e
-            @error "could not spawn process `$(x.def)`! Come across `$e`!"
+            x.stop_time = now()
+            @error "come across `$e` when running!"
             x.status = e isa InterruptException ? INTERRUPTED : FAILED
             e
         end
-        x.stop_time = now()
         row = filter(row -> row.id == x.id, JOB_REGISTRY)
         row.status = x.status
         row.stop_time = x.stop_time

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -99,13 +99,12 @@ function run!(x::AtomicJob)
         catch e
             @error "could not spawn process `$(x.def)`! Come across `$e`!"
             e
-        finally
-            x.stop_time = now()
-            row = filter(row -> row.id == x.id, JOB_REGISTRY)
-            row.stop_time = x.stop_time
-            row.duration = x.stop_time - x.start_time
-            x.outmsg = captured.output
         end
+        x.stop_time = now()
+        row = filter(row -> row.id == x.id, JOB_REGISTRY)
+        row.stop_time = x.stop_time
+        row.duration = x.stop_time - x.start_time
+        x.outmsg = captured.output
         if ref isa Exception  # Include all cases?
             if ref isa InterruptException
                 x.status = INTERRUPTED

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -118,10 +118,10 @@ function run!(job::AtomicJob)
             e
         end
         # Update JOB_REGISTRY
-        row = filter(row -> row.id == job.id, JOB_REGISTRY)
-        row.status = job.status
-        row.stop_time = job.stop_time
-        row.duration = job.stop_time - job.start_time
+        rows = filter(row -> row.id == job.id, JOB_REGISTRY)
+        rows[:, :status] .= job.status
+        rows[:, :stop_time] .= job.stop_time
+        rows[:, :duration] .= job.stop_time - job.start_time
         # Return the result
         ref
     end

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -69,7 +69,7 @@ AtomicJob(job::AtomicJob) =
 
 const JOB_REGISTRY = DataFrame(
     id = UUID[],
-    def = Any[],
+    def = String[],
     created_time = DateTime[],
     start_time = DateTime[],
     stop_time = Union{DateTime,Nothing}[],
@@ -89,7 +89,16 @@ function run!(x::AtomicJob)
         x.start_time = now()
         push!(
             JOB_REGISTRY,
-            (x.id, x.def, x.created_time, x.start_time, nothing, nothing, x.status, x),
+            (
+                x.id,
+                string(x.def),
+                x.created_time,
+                x.start_time,
+                nothing,
+                nothing,
+                x.status,
+                x,
+            ),
         )
         ref = try
             _call(x.def)


### PR DESCRIPTION
- Fix operations on `row` blocks the execution of `run!`
- Change `try` & `catch`, make more accurate timing & errors
- Fix the `try...catch` statement in `run!` which was blocking & has some undefined variables like `captured`
- Fix `Update JOB_REGISTRY` part in `run!`:
  - In the [current design](https://github.com/MineralsCloud/SimpleWorkflow.jl/blob/ccbe904924c7881faf51bacf1125c89da8f79481/src/SimpleWorkflow.jl#L86-L129), it will return multiple rows since
the same job can appear multiple times in the `JOB_REGISTRY` because of
their different created time.