### PR TITLE
Fix `_register!` result since `query` returns a `DataFrame`, not a `DataFrameRow`

### DIFF
--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -1,6 +1,6 @@
 module SimpleWorkflow
 
-using DataFrames: DataFrame, sort
+using DataFrames: DataFrame, nrow, sort, filter
 using Dates: DateTime, Period, Day, now, format
 using Distributed: Future, @spawn
 using IOCapture: capture

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -163,7 +163,7 @@ function queue(; all = true, sortby = :created_time)
     end
 end
 
-query(id::Union{Int64,AbstractVector{Int64}}) = filter(row -> row.id == id, JOB_REGISTRY)
+query(id::Union{Integer,AbstractVector}) = filter(row -> row.id == id, JOB_REGISTRY)
 
 getstatus(x::Job) = x.status
 

--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -118,7 +118,7 @@ function _register!(job::AtomicJob)
     )
     result = _run!(job)
     # Update JOB_REGISTRY
-    row = query(job.id)
+    row = first(query(job.id))  # `query` returns a `DataFrame`, not a `DataFrameRow`
     row.status = job.status
     row.stop_time = job.stop_time
     row.duration = job.stop_time - job.start_time


### PR DESCRIPTION
this bug was introduced in commit
[7dd3031](https://github.com/MineralsCloud/SimpleWorkflow.jl/commit/7dd30317a7bffaacb37cda331041e6f6a2b91f20)
in #40